### PR TITLE
fix: Lambda@Edge to resolve default directory index issue

### DIFF
--- a/lambda-policy.tf
+++ b/lambda-policy.tf
@@ -1,0 +1,13 @@
+data "aws_iam_policy_document" "lambda_policy" {
+  version   = "2012-10-17"
+  policy_id = "PolicyForLambdaEdgeLogging"
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    effect    = "Allow"
+    resources = ["arn:aws:logs:*:*:*"]
+  }
+}


### PR DESCRIPTION
I'm using an origin access identity to access a private
s3 endpoint, only the REST API endpoint is available for
CloudFront. This means that the Defaul Directory Index feature
isn't available. This Lambda@Edge function will rewrite URL's by
appending index.html so that CloudFront can find the s3 key when
given an URL slug.